### PR TITLE
Set .NET tool version to 2.2.x

### DIFF
--- a/.github/workflows/dotnet-ci.yml
+++ b/.github/workflows/dotnet-ci.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 2.1.201
+        dotnet-version: 2.2.x
     - name: NPM Install
       run: npm install
       working-directory: PokemonGoRaidBot

--- a/.github/workflows/dotnet-ci.yml
+++ b/.github/workflows/dotnet-ci.yml
@@ -34,5 +34,9 @@ jobs:
     - name: Test
       run: dotnet test --no-restore --verbosity normal
     - name: Publish
-      run: dotnet publish PokemonGoRaidBot.csproj -c Release /p:PublishProfile=create-deployment-package.pubxml
+      run: dotnet publish PokemonGoRaidBot.csproj -c Release /p:PublishProfile=deploy-to-bin-folder.pubxml
       working-directory: PokemonGoRaidBot
+    - uses: actions/upload-artifact@v2
+      with:
+        name: published-package
+        path: PokemonGoRaidBot/bin/Release/netcoreapp2.1/publish

--- a/.github/workflows/dotnet-ci.yml
+++ b/.github/workflows/dotnet-ci.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 3.1.301
+        dotnet-version: 2.1.201
     - name: NPM Install
       run: npm install
       working-directory: PokemonGoRaidBot

--- a/.github/workflows/dotnet-ci.yml
+++ b/.github/workflows/dotnet-ci.yml
@@ -2,7 +2,7 @@ name: AmersfoortRaidBot CI
 
 on:
   push:
-    branches: [ master, topic/2-setup-ci-build ]
+    branches: [ master ]
   pull_request:
     branches: [ master ]
 

--- a/.github/workflows/dotnet-ci.yml
+++ b/.github/workflows/dotnet-ci.yml
@@ -33,3 +33,6 @@ jobs:
       run: dotnet build --configuration Release --no-restore
     - name: Test
       run: dotnet test --no-restore --verbosity normal
+    - name: Publish
+      run: dotnet publish PokemonGoRaidBot.csproj -c Release /p:PublishProfile=create-deployment-package.pubxml
+      working-directory: PokemonGoRaidBot

--- a/.github/workflows/dotnet-ci.yml
+++ b/.github/workflows/dotnet-ci.yml
@@ -2,7 +2,7 @@ name: AmersfoortRaidBot CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, topic/2-setup-ci-build ]
   pull_request:
     branches: [ master ]
 

--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,6 @@ bld/
 [Bb]in/
 [Oo]bj/
 [Ll]og/
-PokemonGoRaidBot/packages
 
 # Visual Studio 2015 cache/options directory
 .vs/

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ bld/
 [Bb]in/
 [Oo]bj/
 [Ll]og/
+PokemonGoRaidBot/packages
 
 # Visual Studio 2015 cache/options directory
 .vs/

--- a/PokemonGoRaidBot/.config/dotnet-tools.json
+++ b/PokemonGoRaidBot/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "dotnet-ef": {
+      "version": "3.1.7",
+      "commands": [
+        "dotnet-ef"
+      ]
+    }
+  }
+}

--- a/PokemonGoRaidBot/PokemonGoRaidBot.csproj
+++ b/PokemonGoRaidBot/PokemonGoRaidBot.csproj
@@ -3,6 +3,7 @@
     <PropertyGroup>
         <TargetFramework>netcoreapp2.1</TargetFramework>
         <TypeScriptCompileBlocked>true</TypeScriptCompileBlocked>
+        <UserSecretsId>38e86c8c-6278-4983-9b06-0c531cfdeddf</UserSecretsId>
     </PropertyGroup>
 
     <ItemGroup>

--- a/PokemonGoRaidBot/Properties/PublishProfiles/create-deployment-package.pubxml
+++ b/PokemonGoRaidBot/Properties/PublishProfiles/create-deployment-package.pubxml
@@ -12,7 +12,7 @@ by editing this MSBuild file. In order to learn more about this please visit htt
     <LaunchSiteAfterPublish>True</LaunchSiteAfterPublish>
     <ExcludeApp_Data>False</ExcludeApp_Data>
     <ProjectGuid>435a5f11-2efa-4aac-b1f3-be6d21d7308a</ProjectGuid>
-    <DesktopBuildPackageLocation>packages\PokemonGoRaidBot.zip</DesktopBuildPackageLocation>
+    <DesktopBuildPackageLocation>bin\packages\PokemonGoRaidBot.zip</DesktopBuildPackageLocation>
     <PackageAsSingleFile>true</PackageAsSingleFile>
     <DeployIisAppPath>PokemonGoRaidBot</DeployIisAppPath>
   </PropertyGroup>

--- a/PokemonGoRaidBot/Properties/PublishProfiles/create-deployment-package.pubxml
+++ b/PokemonGoRaidBot/Properties/PublishProfiles/create-deployment-package.pubxml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+This file is used by the publish/package process of your Web project. You can customize the behavior of this process
+by editing this MSBuild file. In order to learn more about this please visit https://go.microsoft.com/fwlink/?LinkID=208121. 
+-->
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <WebPublishMethod>Package</WebPublishMethod>
+    <LastUsedBuildConfiguration>Release</LastUsedBuildConfiguration>
+    <LastUsedPlatform>Any CPU</LastUsedPlatform>
+    <SiteUrlToLaunchAfterPublish />
+    <LaunchSiteAfterPublish>True</LaunchSiteAfterPublish>
+    <ExcludeApp_Data>False</ExcludeApp_Data>
+    <ProjectGuid>435a5f11-2efa-4aac-b1f3-be6d21d7308a</ProjectGuid>
+    <DesktopBuildPackageLocation>packages\PokemonGoRaidBot.zip</DesktopBuildPackageLocation>
+    <PackageAsSingleFile>true</PackageAsSingleFile>
+    <DeployIisAppPath>PokemonGoRaidBot</DeployIisAppPath>
+  </PropertyGroup>
+</Project>

--- a/PokemonGoRaidBot/Properties/PublishProfiles/deploy-to-bin-folder.pubxml
+++ b/PokemonGoRaidBot/Properties/PublishProfiles/deploy-to-bin-folder.pubxml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+https://go.microsoft.com/fwlink/?LinkID=208121. 
+-->
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <DeleteExistingFiles>False</DeleteExistingFiles>
+    <ExcludeApp_Data>False</ExcludeApp_Data>
+    <LaunchSiteAfterPublish>True</LaunchSiteAfterPublish>
+    <LastUsedBuildConfiguration>Release</LastUsedBuildConfiguration>
+    <LastUsedPlatform>Any CPU</LastUsedPlatform>
+    <PublishProvider>FileSystem</PublishProvider>
+    <PublishUrl>bin\Release\netcoreapp2.1\publish</PublishUrl>
+    <WebPublishMethod>FileSystem</WebPublishMethod>
+    <SiteUrlToLaunchAfterPublish />
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <ProjectGuid>435a5f11-2efa-4aac-b1f3-be6d21d7308a</ProjectGuid>
+    <SelfContained>false</SelfContained>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
Needed to change  the .NET tool version to stop the build from failing on. .NET Tool Version 

```
/home/runner/.nuget/packages/microsoft.aspnetcore.razor.design/2.1.2/build/netstandard2.0/Microsoft.AspNetCore.Razor.Design.CodeGeneration.targets(69,5): error : rzc discover exited with code 150. [/home/runner/work/amersfoortraidbot/amersfoortraidbot/PokemonGoRaidBot/PokemonGoRaidBot.csproj]
```